### PR TITLE
Update the fiat backend to use the fiat-crypto package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ subtle = { version = "^2.2.1", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 packed_simd = { version = "0.3", features = ["into_bits"], optional = true }
 zeroize = { version = "1", default-features = false }
-curve25519-fiat = { git="https://github.com/calibra/rust-curve25519-fiat.git", version = "0.1.0", optional = true}
+fiat-crypto = { version = "0.1.0", optional = true}
 
 [features]
 nightly = ["subtle/nightly"]
@@ -56,7 +56,7 @@ u32_backend = []
 # The u64 backend uses u64s with u128 products.
 u64_backend = []
 # The fiat-u64 backend uses u64s with u128 products.
-fiat_u64_backend = ["curve25519-fiat"]
+fiat_u64_backend = ["fiat-crypto"]
 # The SIMD backend uses parallel formulas, using either AVX2 or AVX512-IFMA.
 simd_backend = ["nightly", "u64_backend", "packed_simd"]
 # DEPRECATED: this is now an alias for `simd_backend` and may be removed

--- a/src/backend/serial/fiat/field.rs
+++ b/src/backend/serial/fiat/field.rs
@@ -22,7 +22,7 @@ use subtle::ConditionallySelectable;
 
 use zeroize::Zeroize;
 
-use curve25519_fiat::curve25519_64::*;
+use fiat_crypto::curve25519_64::*;
 
 /// A `FieldElement51` represents an element of the field
 /// \\( \mathbb Z / (2\^{255} - 19)\\).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ extern crate rand_core;
 extern crate zeroize;
 
 #[cfg(feature = "fiat_u64_backend")]
-extern crate curve25519_fiat;
+extern crate fiat_crypto;
 
 // Used for traits related to constant-time code.
 extern crate subtle;


### PR DESCRIPTION
This allows a cleaner dependency on fiat, and obsoletes [our legacy package](https://github.com/calibra/rust-curve25519-fiat)
The new package is published by fiat at https://crates.io/crates/fiat-crypto on each release.