### PR TITLE
[backport] Update the fiat backend to use the fiat-crypto package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
-curve25519-fiat = { git="https://github.com/calibra/rust-curve25519-fiat.git", version = "0.1.0", optional = true}
+fiat-crypto = { version = "0.1.0", optional = true}
 
 [build-dependencies]
 rand_core = { version = "0.3.0", default-features = false }
@@ -61,7 +61,7 @@ clear_on_drop = "=0.2.3"
 subtle = { version = "2", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true }
 packed_simd = { version = "0.3.0", features = ["into_bits"], optional = true }
-curve25519-fiat = { git="https://github.com/calibra/rust-curve25519-fiat.git", version = "0.1.0", optional = true}
+fiat-crypto = { version = "0.1.0", optional = true}
 
 [features]
 nightly = ["subtle/nightly", "clear_on_drop/nightly"]
@@ -75,7 +75,7 @@ u32_backend = []
 # The u64 backend uses u64s with u128 products.
 u64_backend = []
 # The fiat-u64 backend uses u64s with u128 products.
-fiat_u64_backend = ["curve25519-fiat"]
+fiat_u64_backend = ["fiat-crypto"]
 # The SIMD backend uses parallel formulas, using either AVX2 or AVX512-IFMA.
 simd_backend = ["nightly", "u64_backend", "packed_simd"]
 # Old name for the SIMD backend, preserved for compatibility

--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,7 @@ use std::path::Path;
 extern crate serde;
 
 #[cfg(feature = "fiat_u64_backend")]
-extern crate curve25519_fiat;
+extern crate fiat_crypto;
 
 // Macros come first!
 #[path = "src/macros.rs"]

--- a/src/backend/serial/fiat/field.rs
+++ b/src/backend/serial/fiat/field.rs
@@ -20,7 +20,7 @@ use core::ops::{Sub, SubAssign};
 use subtle::Choice;
 use subtle::ConditionallySelectable;
 
-use curve25519_fiat::curve25519_64::*;
+use fiat_crypto::curve25519_64::*;
 
 /// A `FieldElement51` represents an element of the field
 /// \\( \mathbb Z / (2\^{255} - 19)\\).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ extern crate rand_core;
 extern crate rand_os;
 
 #[cfg(feature = "fiat_u64_backend")]
-extern crate curve25519_fiat;
+extern crate fiat_crypto;
 
 // Used for traits related to constant-time code.
 extern crate subtle;


### PR DESCRIPTION
This is a pure backport of the change in https://github.com/calibra/curve25519-dalek/pull/6 to the legacy fiat / dalek-on-curve25519 1.0 fork.